### PR TITLE
pass origin rowData to onDrop function

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -23,7 +23,7 @@ const moveSource = {
 
     let dropRealTime = props.getDropRealTime()
     dropRealTime = nearestTime(dropRealTime - item.grabOffset, props.dropRounding)
-    props.onDrop(item, {moveTo: dropRealTime}, dropResult.rowData)
+    props.onDrop(item, props.rowData, {...dropResult, moveTo: dropRealTime})
   },
 }
 function moveCollect(connect, monitor) {

--- a/src/row.js
+++ b/src/row.js
@@ -268,6 +268,7 @@ class Row extends React.Component {
           onClick={this.handleEventClick}
           onDrop={this.props.onEventDrop}
           getDropRealTime={this.getDropRealTime}
+          rowData={this.props.rowData}
         />
       )
     })


### PR DESCRIPTION
pass origin rowData to onDrop function, reorder arguments for consistence with bucketed-scheduler

This is fine as long as only uptick workforce currently uses this package.  Otherwise, could add in the row data without reordering the arguments.